### PR TITLE
Avoid shell injection from github.head_ref in the CI push step

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -32,6 +32,8 @@ jobs:
           black .
 
       - name: Commit and push formatting changes
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           # Check if any files have been modified
           if [ -n "$(git status --porcelain)" ]; then
@@ -39,7 +41,7 @@ jobs:
             git config --global user.email "github-actions@github.com"
             git add .
             git commit -m "Auto apply black [skip ci]"
-            git push origin ${{ github.head_ref }}  # Push changes to the same PR branch
+            git push origin "$HEAD_REF"  # Push changes to the same PR branch
           else
             echo "No formatting changes detected."
           fi


### PR DESCRIPTION
The auto-formatting job in `.github/workflows/pytest.yml` pushes back to the contributor's branch with:

```yaml
git push origin ${{ github.head_ref }}
```

`github.head_ref` is the head branch name of the incoming pull request, which the author controls. When that expression is expanded directly inside a `run:` block, GitHub substitutes the literal value into the script before the shell parses it, so a branch named to include shell metacharacters could run arbitrary commands on the runner. GitHub documents this script-injection risk here: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections

The patch reads the value through a step-level `env:` entry and references the quoted shell variable:

```yaml
- name: Commit and push formatting changes
  env:
    HEAD_REF: ${{ github.head_ref }}
  run: |
    ...
    git push origin "$HEAD_REF"
```

Going through `env` means the branch name arrives as an ordinary environment value instead of being spliced into the command, so it cannot be interpreted as code. Nothing else in the step changes, and the `ref: ${{ github.head_ref }}` used by `actions/checkout` is a safe action input so I left it as is. Tools like zizmor and CodeQL's `actions/expression-injection` query report the original pattern.